### PR TITLE
-ms: .KS after .1C bug fixed

### DIFF
--- a/sys/lib/tmac/tmac.s
+++ b/sys/lib/tmac/tmac.s
@@ -972,7 +972,7 @@ Computing Science Technical Report No. \\*(MN
 .fi
 .if (\\n(nl+1v)>(\\n(.p-\\n(FM) \{\
 .	if \\n(NX>1 .RC
-.	if \\n(NX<1 .bp\}
+.	if \\n(NX<=1 .bp\}
 .nr TD 0
 ..
 .de KD
@@ -1020,7 +1020,7 @@ Computing Science Technical Report No. \\*(MN
 .if !\\n(dn .nr WF 0
 .if \\n(FC<=1 .if \\n(XX=0 \{\
 .	if \\n(NX>1 .RC
-.	if \\n(NX<1 'bp\}
+.	if \\n(NX<=1 'bp\}
 .nr FC -1
 .if \\n(ML>0 .ne \\n(MLu
 ..


### PR DESCRIPTION
Executing `.KS` after `.1C` exhibits a bug. Instead on the next page, the text between `.KS` and `.KE` is shown at the bottom of the page (where footnote would be).